### PR TITLE
fix(BET-3530): upgrade Fullsail package ID in SDK fallback

### DIFF
--- a/src/features/swap/config.ts
+++ b/src/features/swap/config.ts
@@ -149,7 +149,7 @@ export const DEFAULT_CONFIG: Config = {
   fullsail: {
     name: "Fullsail",
     package:
-      "0xe1b7d5fd116fea5a8f8e85c13754248d56626a8d0a614b7d916c2348d8323149",
+      "0x497a144ba3d93ae44d9fd23d4ff4761c329d87a505136d2269c743b2297fa881",
     globalConfig:
       "0xe93baa80cb570b3a494cbf0621b2ba96bc993926d34dc92508c9446f9a05d615",
     rewarderGlobalVault:

--- a/src/features/swap/config.ts
+++ b/src/features/swap/config.ts
@@ -149,7 +149,7 @@ export const DEFAULT_CONFIG: Config = {
   fullsail: {
     name: "Fullsail",
     package:
-      "0x497a144ba3d93ae44d9fd23d4ff4761c329d87a505136d2269c743b2297fa881",
+      "0x79ec5afe0d43c398a88978aacda103c9b5b1ec9027333e315fad34b0d52ff238",
     globalConfig:
       "0xe93baa80cb570b3a494cbf0621b2ba96bc993926d34dc92508c9446f9a05d615",
     rewarderGlobalVault:


### PR DESCRIPTION
## Summary
- Update `DEFAULT_CONFIG` fallback to use latest Fullsail on-chain package ID (v4)
- Companion PR to the aggregator-api config update

## Test plan
- [ ] Verify SDK fallback config has correct package ID
- [ ] Test swap through Fullsail when API config endpoint is unavailable

🤖 Generated with [Claude Code](https://claude.com/claude-code)